### PR TITLE
Add Pagerduty Annotation

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     github.com/project-slug: roadiehq/sync-techdocs-action
     backstage.io/techdocs-ref: dir:.
+    pagerduty.com/service-id: P2RXCGR
 spec:
   type: library
   owner: RoadieHQ


### PR DESCRIPTION
This adds an annotation for the Pagerduty service linked to this Lambda so that it works in Backstage